### PR TITLE
fix(chart): disable metrics rbac

### DIFF
--- a/chart/k8sprom-patch-controller/Chart.yaml
+++ b/chart/k8sprom-patch-controller/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.2.0
+appVersion: 0.2.0
 description: Patch kubernetes resources using prometheus queries
 home: https://github.com/DoodleScheduling/k8sprom-patch-controller
 maintainers:
@@ -12,4 +12,4 @@ keywords:
 name: k8sprom-patch-controller
 sources:
 - https://github.com/DoodleScheduling/k8sprom-patch-controller
-version: 0.3.0
+version: 0.4.0

--- a/chart/k8sprom-patch-controller/templates/metrics-rbac.yaml
+++ b/chart/k8sprom-patch-controller/templates/metrics-rbac.yaml
@@ -30,6 +30,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "k8sprom-patch-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/chart/k8sprom-patch-controller/templates/podmonitor.yaml
+++ b/chart/k8sprom-patch-controller/templates/podmonitor.yaml
@@ -22,7 +22,6 @@ spec:
     {{- if .Values.kubeRBACProxy.enabled }}  
     port: https
     scheme: https
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     tlsConfig:
       insecureSkipVerify: true
     {{- else }}

--- a/chart/k8sprom-patch-controller/values.yaml
+++ b/chart/k8sprom-patch-controller/values.yaml
@@ -125,6 +125,6 @@ prometheusRule:
   rules: []
 
 kubeRBACProxy:
-  enabled: true
+  enabled: false
 
 tolerations: []


### PR DESCRIPTION
## Current situation
The PodMonitor in combination with kube-rbac-proxy does not work.
Apparantly this is an incompatible feature in the pod monitor specs, see https://github.com/prometheus-operator/prometheus-operator/pull/5262

## Proposal
Disable kube-rbac-proxy by default for now.
(Workaround would be to use a ServiceMonitor, which would require a Service as well)
