### PR TITLE
feat(chart): add bearer token auth secret for metrics

### DIFF
--- a/chart/k8sprom-patch-controller/Chart.yaml
+++ b/chart/k8sprom-patch-controller/Chart.yaml
@@ -12,4 +12,4 @@ keywords:
 name: k8sprom-patch-controller
 sources:
 - https://github.com/DoodleScheduling/k8sprom-patch-controller
-version: 0.4.0
+version: 0.5.0

--- a/chart/k8sprom-patch-controller/templates/podmonitor.yaml
+++ b/chart/k8sprom-patch-controller/templates/podmonitor.yaml
@@ -22,6 +22,9 @@ spec:
     {{- if .Values.kubeRBACProxy.enabled }}  
     port: https
     scheme: https
+    bearerTokenSecret: 
+      key: token
+      name: {{ template "k8sprom-patch-controller.serviceAccountName" . }}
     tlsConfig:
       insecureSkipVerify: true
     {{- else }}

--- a/chart/k8sprom-patch-controller/templates/serviceaccount-token.yaml
+++ b/chart/k8sprom-patch-controller/templates/serviceaccount-token.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "k8sprom-patch-controller.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "k8sprom-patch-controller.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "k8sprom-patch-controller.chart" . }}
+  annotations:
+    kubernetes.io/service-account.name: {{ template "k8sprom-patch-controller.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end -}}

--- a/chart/k8sprom-patch-controller/values.yaml
+++ b/chart/k8sprom-patch-controller/values.yaml
@@ -125,6 +125,6 @@ prometheusRule:
   rules: []
 
 kubeRBACProxy:
-  enabled: false
+  enabled: true
 
 tolerations: []


### PR DESCRIPTION
## Current situation
There is no bearer token configured for the PodMonitor if kubeRBACProxy.enabled is true.

## Proposal
Set bearer secret if the proxy is enabled.
